### PR TITLE
feat: initial strct for custom provider markets

### DIFF
--- a/apps/api/app/api/[...route]/utils/constants.ts
+++ b/apps/api/app/api/[...route]/utils/constants.ts
@@ -1,3 +1,4 @@
 export const GAMMA_API_URL = 'https://gamma-api.polymarket.com';
 export const DEFAULT_LIMITLESS_TAG = 'limitless';
 export const DEFAULT_POLYMARKET_TAG = 'polymarket';
+export const DEFAULT_CUSTOM_PROVIDER_TAG = 'custom';

--- a/apps/api/app/schemas/index.ts
+++ b/apps/api/app/schemas/index.ts
@@ -105,7 +105,7 @@ const MarketSchema = z.object({
     .optional(),
   creator: CreatorSchema,
   chainId: z.number(),
-  provider: z.literal('polymarket').or(z.literal('limitless')),
+  provider: z.literal('polymarket').or(z.literal('limitless')).or(z.literal('custom')),
 });
 
 export const SupabaseMarketSchema = z.object({
@@ -145,7 +145,7 @@ const MarketGroupCardResponseSchema = z.object({
   slug: z.string(),
   title: z.string(),
   imageUrl: z.string(),
-  provider: z.literal('polymarket').or(z.literal('limitless')),
+  provider: z.literal('polymarket').or(z.literal('limitless')).or(z.literal('custom')),
   deadline: z.string(),
   category: z.array(z.string()),
   collateralToken: CollateralTokenSchema,

--- a/apps/api/app/services/market/MarketProviderFactory.ts
+++ b/apps/api/app/services/market/MarketProviderFactory.ts
@@ -1,4 +1,5 @@
 import { MarketProvider } from './MarketProvider';
+import { CustomProvider } from './providers/CustomProvider';
 import { LimitlessProvider } from './providers/LimitlessProvider';
 import { PolymarketProvider } from './providers/PolymarketProvider';
 
@@ -9,8 +10,8 @@ export class MarketProviderFactory {
         return new PolymarketProvider();
       case 'limitless':
         return new LimitlessProvider();
-      //   case 'custom':
-      //     return new CustomProvider();
+        case 'custom':
+          return new CustomProvider();
       default:
         throw new Error(`Unsupported provider: ${provider}`);
     }

--- a/apps/api/app/services/market/providers/CustomProvider.ts
+++ b/apps/api/app/services/market/providers/CustomProvider.ts
@@ -1,16 +1,36 @@
 import { MarketsWithMetadata, PaginatedMarketResponse } from '@/types/market';
 import { BaseProvider } from './BaseProvider';
-
+import { supabase } from '@/app/api/[...route]/utils';
+import { transformCustomResponse } from '../transformers/customTransformer';
 export class CustomProvider extends BaseProvider {
   async getMarket(marketId: string): Promise<MarketsWithMetadata> {
-    // TODO: Implement CustomProvider-specific fetching logic
-    return null as any;
+    const { data } = await supabase
+      .from('markets')
+      .select('*')
+      .eq('eventSlug', marketId)
+      .limit(1)
+      .maybeSingle();
+
+    if (!data) {
+      return {
+        data: [],
+        metadata: null,
+      };
+    }
+    // Fetch metadata from Supabase
+    const metadata = await this.fetchMetadata(marketId);
+    // Transform the response
+    return transformCustomResponse(data, metadata);
   }
+
+  // TODO
   async getMarkets(
     limit: number,
     offset: string = '0',
   ): Promise<PaginatedMarketResponse> {
-    // TODO: Implement CustomProvider-specific fetching logic
-    return null as any;
+    return {
+      markets: [],
+      nextCursor: null,
+    };
   }
 }

--- a/apps/api/app/services/market/transformers/customTransformer.ts
+++ b/apps/api/app/services/market/transformers/customTransformer.ts
@@ -1,0 +1,53 @@
+import { DEFAULT_CUSTOM_PROVIDER_TAG } from '@/app/api/[...route]/utils/constants';
+import { MarketMetadata, MarketsWithMetadata } from '@/types/market';
+import { Tables } from '@repo/shared-types';
+
+export function transformCustomResponse(
+  market: Tables<'markets'>,
+  metadata: MarketMetadata | null,
+): MarketsWithMetadata {
+  const metadataTags = metadata?.tags?.map((t) => t.toLowerCase()) ?? [];
+  return {
+    data: [
+      {
+        id: market.eventSlug!,
+        title: market.title,
+        description: market.description,
+        outcomePrices: ['50', '50'],
+        collateralToken: {
+          address: '0x3c499c542cef5e3811e1192ce70d8cc03d5c3359',
+          decimals: 6,
+          symbol: 'USDC',
+        },
+        conditionId: market.id.toString(),
+        creator: {
+          name: 'Viral Games',
+        },
+        expirationDate: market.createdAt, // TODO
+        expirationTimestamp: new Date(market.createdAt).getTime(), // TODO
+        expired: false,
+        liquidity: '0',
+        liquidityFormatted: '0',
+        ogImageURI:
+          metadata?.image_uri ??
+          market.imageUrl ??
+          'https://nzavwarwntmwtfrkfput.supabase.co/storage/v1/object/public/markets_images/app-logo.svg?t=2024-08-23T09%3A29%3A21.086Z',
+        tags: [...metadataTags, DEFAULT_CUSTOM_PROVIDER_TAG],
+        // volume: market.volume,
+        volumeFormatted: '0',
+        winningOutcomeIndex: null, // TODO
+        chainId: 8453,
+        provider: 'custom',
+      },
+    ],
+    metadata: {
+      // ...metadata, NOTE: Currently metadata for Polymarket is not set in supabase
+      address: metadata?.address ?? null,
+      created_at: metadata?.created_at ?? null,
+      image_uri: metadata?.image_uri ?? market.imageUrl,
+      tags: metadataTags,
+      provider: 'custom',
+      title: metadata?.title ?? market.title,
+    },
+  };
+}

--- a/apps/api/types/market.ts
+++ b/apps/api/types/market.ts
@@ -57,7 +57,7 @@ export interface Market {
   };
   creator: Creator;
   chainId: number;
-  provider: 'polymarket' | 'limitless';
+  provider: 'polymarket' | 'limitless' | 'custom';
 }
 
 type OverviewMarket = Tables<'events'> & {

--- a/apps/web/lib/actions/viral-games-api.ts
+++ b/apps/web/lib/actions/viral-games-api.ts
@@ -47,7 +47,7 @@ export async function buyShares({
   position,
 }: {
   socialProvider: 'eoa' | 'farcaster';
-  provider: 'limitless' | 'polymarket';
+  provider: 'limitless' | 'polymarket' | 'custom';
   userId: string;
   marketId: string;
   eventId: string;

--- a/apps/web/lib/hooks/react-query/mutations/useFreeBetMutation.ts
+++ b/apps/web/lib/hooks/react-query/mutations/useFreeBetMutation.ts
@@ -10,7 +10,7 @@ type ExchangePosition = {
   position: 'Yes' | 'No';
 };
 
-export function useFreeBetMutation(marketProvider: 'limitless' | 'polymarket') {
+export function useFreeBetMutation(marketProvider: 'limitless' | 'polymarket' | 'custom') {
   const queryClient = useQueryClient();
   const account = useAccount();
   const params = useParams<{ market_params: Array<string> }>();

--- a/apps/web/src/app/markets/[...market_params]/components/exchange/BuyTab.tsx
+++ b/apps/web/src/app/markets/[...market_params]/components/exchange/BuyTab.tsx
@@ -52,7 +52,7 @@ export function BuyTab({
     mutateAsync: freeBet,
     error: freeExchangeError,
     isPending: isSubmittingFreeBet,
-  } = useFreeBetMutation(marketProvider as 'limitless' | 'polymarket');
+  } = useFreeBetMutation(marketProvider as 'limitless' | 'polymarket' | 'custom');
   const { triggerSuccessToast } = useSuccessToast();
 
   const [isProcessing, setIsProcessing] = useState(false);

--- a/apps/web/src/app/markets/[...market_params]/components/exchange/MarketExchange.tsx
+++ b/apps/web/src/app/markets/[...market_params]/components/exchange/MarketExchange.tsx
@@ -138,7 +138,7 @@ export default function MarketExchange() {
             id='free-bet-toggle'
             checked={defaultSwitchValue}
             onCheckedChange={handleFreeBetToggle}
-            disabled={provider === 'polymarket'}
+            disabled={provider === 'polymarket' || provider === 'custom'}
           />
           <Label htmlFor='free-bet-toggle'>Free Bet</Label>
         </div>


### PR DESCRIPTION
1. Enable "details" support for `custom` markets